### PR TITLE
[upgraded] to tslint@4

### DIFF
--- a/formatters/junitFormatter.ts
+++ b/formatters/junitFormatter.ts
@@ -1,5 +1,5 @@
 import * as ts from "typescript";
-import * as Lint from "tslint/lib/lint";
+import * as Lint from "tslint";
 
 /*
  * TSLint formatter that adheres to the JUnit XML specification.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tslint-junit-formatter",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "JUnit XML formatter for TSlint.",
   "main": "formatters/junitFormatter.js",
   "scripts": {
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/GenoLogics-OpenSource/tslint-junit-formatter#readme",
   "peerDependencies": {
-    "tslint": "^3.0.0"
+    "tslint": "^4.0.0"
   },
   "devDependencies": {
     "typescript": "^1.8.10"


### PR DESCRIPTION
I had to change the link to `tslint` to use it with `tslint@4.5.1`.