### PR TITLE
Updated to support TSLint 5.x

### DIFF
--- a/formatters/junitFormatter.ts
+++ b/formatters/junitFormatter.ts
@@ -1,5 +1,4 @@
-import * as ts from "typescript";
-import * as Lint from "tslint/lib/lint";
+import * as Lint from "tslint";
 
 /*
  * TSLint formatter that adheres to the JUnit XML specification.
@@ -33,29 +32,29 @@ export class Formatter extends Lint.Formatters.AbstractFormatter {
      * Generate an error <testcase> element
      */
     private testcaseXML(ruleFailure: Lint.RuleFailure): string {
-        var ruleName = this.generateName(ruleFailure.getRuleName());
-        var message = this.escape(ruleFailure.getFailure());
-        var startPosition = ruleFailure.getStartPosition();
-        var { line, character } = startPosition.getLineAndCharacter();
-        var fileName = ruleFailure.getFileName();
+        const ruleName = this.generateName(ruleFailure.getRuleName());
+        const message = this.escape(ruleFailure.getFailure());
+        const startPosition = ruleFailure.getStartPosition();
+        const { line, character } = startPosition.getLineAndCharacter();
+        const fileName = ruleFailure.getFileName();
 
-        return `<testcase time=\"0\" name=\"${ruleName}\"><error message=\"${message} (${ruleName})\"><![CDATA[${line}:${character}:${fileName}]]></error></testcase>`;
+        return `<testcase time="0" name="${ruleName}"><error message="${message} (${ruleName})"><![CDATA[${line}:${character}:${fileName}]]></error></testcase>`;
     }
 
     /**
      * Generate a <testsuite> element without a closing tag
      */
     private testsuiteStartXML(failures: Lint.RuleFailure[]): string {
-        return `<testsuite time=\"0\" tests=\"${failures.length}\" skipped=\"0\" errors=\"${failures.length}\" failures=\"0\" package=\"org.tslint\" name=\"tslint.xml\">`;
+        return `<testsuite time="0" tests="${failures.length}" skipped="0" errors="${failures.length}" failures="0" package="org.tslint" name="tslint.xml">`;
     }
 
     /**
      * Transform lint failure to JUnit XML format
      */
     public format(failures: Lint.RuleFailure[]): string {
-        var xml = [];
+        let xml = [];
 
-        xml.push("<?xml version=\"1.0\" encoding=\"utf-8\"?>");
+        xml.push(`<?xml version="1.0" encoding="utf-8"?>`);
         xml.push("<testsuites>");
 
         if (failures.length > 0) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tslint-junit-formatter",
-  "version": "1.0.0",
+  "version": "5.0.0",
   "description": "JUnit XML formatter for TSlint.",
   "main": "formatters/junitFormatter.js",
   "scripts": {
@@ -24,9 +24,11 @@
   },
   "homepage": "https://github.com/GenoLogics-OpenSource/tslint-junit-formatter#readme",
   "peerDependencies": {
-    "tslint": "^3.0.0"
+    "tslint": "^5.0.0"
   },
   "devDependencies": {
-    "typescript": "^1.8.10"
+    "@types/node": "^7.0.16",
+    "@types/es6-shim": "^0.31.34",
+    "typescript": "^2.3.0"
   }
 }


### PR DESCRIPTION
- Bumped Typescript Version to 2.3.x.
- Bumped TSLint support to 5.x.
- Did some minor cleanup in the formatter.
- Had include some @types dev dependencies to keep the definition files in TSLint peer dependency happy on tsc compile.